### PR TITLE
Properly encode invalid GDL90 tail number characters as 0x20 instead …

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -460,11 +460,7 @@ func makeOwnshipGeometricAltitudeReport() bool {
 	msg[0] = 0x0B // Message type "Ownship Geo Alt".
 
 	var GPSalt float32
-	if globalSettings.GDL90MSLAlt_Enabled {
-		GPSalt = mySituation.GPSAltitudeMSL
-	} else {
-		GPSalt = mySituation.GPSHeightAboveEllipsoid
-	}
+	GPSalt = mySituation.GPSHeightAboveEllipsoid
 	encodedAlt := int16(GPSalt / 5)    // GPS Altitude, encoded to 16-bit int using 5-foot resolution
 	msg[1] = byte(encodedAlt >> 8)     // Altitude.
 	msg[2] = byte(encodedAlt & 0x00FF) // Altitude.
@@ -695,9 +691,9 @@ func makeFFIDMessage() []byte {
 	}
 	copy(msg[19:], devLongName)
 
-	if globalSettings.GDL90MSLAlt_Enabled {
-		msg[38] = 0x01 // Capabilities mask. MSL altitude for Ownship Geometric report.
-	}
+	//if globalSettings.GDL90MSLAlt_Enabled {
+		msg[38] = 0x00 // Capabilities mask. MSL altitude for Ownship Geometric report. We only support HAE as in spec.
+	//}
 
 	return prepareMessage(msg)
 }
@@ -1196,7 +1192,6 @@ type settings struct {
 	WiFiMode             int
 	WiFiDirectPin        string
 	WiFiIPAddress        string
-	GDL90MSLAlt_Enabled  bool
 	SkyDemonAndroidHack  bool
 	EstimateBearinglessDist bool
 	RadarLimits          int
@@ -1295,7 +1290,6 @@ func defaultSettings() {
 	globalSettings.DeveloperMode = true
 	globalSettings.StaticIps = make([]string, 0)
 	globalSettings.NoSleep = false
-	globalSettings.GDL90MSLAlt_Enabled = true
 	globalSettings.SkyDemonAndroidHack = false
 	globalSettings.EstimateBearinglessDist = false
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -432,8 +432,6 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						setWiFiMode(int(val.(float64)))
 					case "WiFiDirectPin":
 						setWifiDirectPin(val.(string))
-					case "GDL90MSLAlt_Enabled":
-						globalSettings.GDL90MSLAlt_Enabled = val.(bool)
 					case "SkyDemonAndroidHack":
 						globalSettings.SkyDemonAndroidHack = val.(bool)
 					case "EstimateBearinglessDist":

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -649,8 +649,8 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	// msg[19] to msg[26] are "call sign" (tail).
 	for i := 0; i < len(ti.Tail) && i < 8; i++ {
 		c := byte(ti.Tail[i])
-		if c != 20 && !((c >= 48) && (c <= 57)) && !((c >= 65) && (c <= 90)) && c != 'e' && c != 'u' && c != 'a' && c != 'r' && c != 't' { // See p.24, FAA ref.
-			c = byte(20)
+		if c != 0x20 && !((c >= 48) && (c <= 57)) && !((c >= 65) && (c <= 90)) && c != 'e' && c != 'u' && c != 'a' && c != 'r' && c != 't' { // See p.24, FAA ref.
+			c = byte(0x20)
 		}
 		msg[19+i] = c
 	}

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -205,13 +205,6 @@
                         </form>
                     </div>
                     <div class="form-group reset-flow">
-                        <label class="control-label col-xs-5">GDL90: Use MSL instead of HAE<br /><small>Disable for
-                                SkyDemon, Enroute</small></label>
-                        <div class="col-xs-5">
-                            <ui-switch ng-model='GDL90MSLAlt_Enabled' settings-change></ui-switch>
-                        </div>
-                    </div>
-                    <div class="form-group reset-flow">
                         <label class="control-label col-xs-5">SkyDemon disconnect bug workaround</label>
                         <div class="col-xs-5">
                             <ui-switch ng-model='SkyDemonAndroidHack' settings-change></ui-switch>


### PR DESCRIPTION
…of decimal 20. Most notably for MODE0x20S vs MODE[dec 20]S,

Removed setting to send GDL90 altitude as MSL, now always sending HAE as the spec mandates